### PR TITLE
i "shot" the SARIF

### DIFF
--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -5,7 +5,7 @@ on:
     # TODO: probably distribute this
     - cron: '30 1 * * 6'
   push:
-    branches: [ main, master ]
+    branches: main
   workflow_dispatch:
 
 permissions: read-all
@@ -15,7 +15,6 @@ jobs:
     name: Scorecard analysis
     runs-on: ubuntu-latest
     permissions:
-      security-events: write
       id-token: write
 
     steps:
@@ -27,24 +26,6 @@ jobs:
       - name: "Run analysis"
         uses: ossf/scorecard-action@08b4669551908b1024bb425080c797723083c031 # v2.2.0
         with:
-          results_file: results.sarif
-          results_format: sarif
           # TODO: gtfo?
           # repo_token: ${{ secrets.SCORECARD_TOKEN }}
-
           publish_results: true
-
-      # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
-      # format to the repository Actions tab.
-      - name: "Upload artifact"
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
-        with:
-          name: SARIF file
-          path: results.sarif
-          retention-days: 5
-
-      # required for Code scanning alerts
-      - name: "Upload SARIF results to code scanning"
-        uses: github/codeql-action/upload-sarif@83f0fe6c4988d98a455712a27f0255212bba9bd4 # v2.3.6
-        with:
-          sarif_file: results.sarif


### PR DESCRIPTION
but i did not shoot the ~deputy~ `publish_results: true`.

I don't see a way to disable the "hey you should be fuzzing" warning, and I don't want to fuzz.
Dismissing alerts like that from N repos is not useful.